### PR TITLE
feat:ニュースをバブルUIで表示し、d3-forceで物理シミュレーションを実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,15 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "d3-force": "^3.0.0",
+        "d3-selection": "^3.0.0",
         "vue": "^3.5.12",
         "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.4",
+        "@types/d3-force": "^3.0.10",
+        "@types/d3-selection": "^3.0.11",
         "@types/node": "^20.17.0",
         "@vitejs/plugin-vue": "^5.1.4",
         "@vue/eslint-config-prettier": "^10.0.0",
@@ -1095,6 +1099,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1877,6 +1895,56 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/de-indent": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,15 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "d3-force": "^3.0.0",
+    "d3-selection": "^3.0.0",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",
+    "@types/d3-force": "^3.0.10",
+    "@types/d3-selection": "^3.0.11",
     "@types/node": "^20.17.0",
     "@vitejs/plugin-vue": "^5.1.4",
     "@vue/eslint-config-prettier": "^10.0.0",

--- a/src/components/NewsMap.vue
+++ b/src/components/NewsMap.vue
@@ -1,75 +1,342 @@
 <script lang="ts" setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed, onUnmounted } from 'vue'
 import axios from 'axios'
-import NewsItem from './NewsItem.vue'
+import * as d3Force from 'd3-force'
 
-const news = ref(null)
+interface NewsArticle {
+  title: string
+  url: string
+  urlToImage?: string
+  description?: string
+  source: {
+    name: string
+  }
+  publishedAt: string
+}
+
+interface BubbleNode extends d3Force.SimulationNodeDatum {
+  id: number
+  article: NewsArticle
+  radius: number
+  color: string
+  fontSize: number
+  popularity: number
+}
+
+const articles = ref<NewsArticle[]>([])
+const bubbleNodes = ref<BubbleNode[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
 const newsApiKey = import.meta.env.VITE_NEWS_API_KEY
 
+let simulation: d3Force.Simulation<BubbleNode, undefined> | null = null
+
+// 物理シミュレーションの初期化
+const initSimulation = () => {
+  if (bubbleNodes.value.length === 0) return
+
+  const containerWidth = window.innerWidth - 100
+  const containerHeight = window.innerHeight - 300
+
+  // 力学シミュレーションを作成
+  simulation = d3Force
+    .forceSimulation<BubbleNode>(bubbleNodes.value)
+    .force('charge', d3Force.forceManyBody().strength(30)) // 互いに反発
+    .force('collision', d3Force.forceCollide<BubbleNode>().radius(d => d.radius + 5)) // 衝突検出
+    .force('center', d3Force.forceCenter(containerWidth / 2, containerHeight / 2)) // 中心に引き寄せ
+    .force('x', d3Force.forceX(containerWidth / 2).strength(0.05)) // X軸方向の弱い力
+    .force('y', d3Force.forceY(containerHeight / 2).strength(0.05)) // Y軸方向の弱い力
+    .alphaDecay(0.02) // ゆっくり収束
+    .on('tick', () => {
+      // 各ティックで位置を更新
+      bubbleNodes.value = [...bubbleNodes.value]
+    })
+}
+
+// ニュース記事を取得
 const fetchNews = async () => {
   try {
-    const res = await axios.get(
-      'https://newsdata.io/api/1/latest?apikey=' + newsApiKey + '&language=jp',
-    )
-    news.value = res.data
-  } catch (error) {
-    console.error('Error fetching data:', error)
+    loading.value = true
+    error.value = null
+
+    // News API v2/top-headlines エンドポイントを使用（人気の記事を取得）
+    const res = await axios.get('https://newsapi.org/v2/top-headlines', {
+      params: {
+        country: 'us', // 国コード (us=アメリカ, jp=日本)
+        category: 'general', // カテゴリ (general, business, technology, sports など)
+        pageSize: 50, // 取得記事数
+        apiKey: newsApiKey
+      }
+    })
+
+    console.log('API Response:', res.data)
+    console.log('Articles count:', res.data.articles?.length)
+    console.log('Status:', res.data.status)
+
+    articles.value = res.data.articles || []
+
+    // 泡ノードを作成
+    const containerWidth = window.innerWidth - 100
+    const containerHeight = window.innerHeight - 300
+
+    bubbleNodes.value = articles.value.map((article, index) => {
+      // 人気度を計算
+      const popularity = articles.value.length - index
+      const maxPopularity = articles.value.length
+      const minPopularity = 1
+      const normalized = (popularity - minPopularity) / (maxPopularity - minPopularity)
+
+      // 泡のサイズとフォントサイズ
+      const radius = 40 + normalized * 100 // 40px ~ 140px
+      const fontSize = 10 + normalized * 8
+
+      // ランダムな色
+      const colors = [
+        '#FF6B6B', '#4ECDC4', '#45B7D1', '#FFA07A',
+        '#98D8C8', '#F7DC6F', '#BB8FCE', '#85C1E2',
+        '#F8B739', '#52B788', '#E76F51', '#2A9D8F'
+      ]
+      const color = colors[Math.floor(Math.random() * colors.length)]
+
+      return {
+        id: index,
+        article,
+        radius,
+        fontSize,
+        color,
+        popularity: Math.round(normalized * 100),
+        x: containerWidth / 2 + (Math.random() - 0.5) * 200, // 中心付近からスタート
+        y: containerHeight / 2 + (Math.random() - 0.5) * 200
+      }
+    })
+
+    // シミュレーション開始
+    initSimulation()
+  } catch (err: any) {
+    console.error('Error fetching news:', err)
+    console.error('Error response:', err.response)
+    console.error('API Key:', newsApiKey ? 'exists' : 'missing')
+    error.value = err.response?.data?.message || err.message || 'ニュースの取得に失敗しました'
+  } finally {
+    loading.value = false
   }
 }
+
+// 表示用のスタイルを計算
+const styledArticles = computed(() => {
+  return bubbleNodes.value.map(node => {
+    return {
+      article: node.article,
+      bubbleSize: `${node.radius * 2}px`,
+      fontSize: `${node.fontSize}px`,
+      left: `${(node.x || 0) - node.radius}px`,
+      top: `${(node.y || 0) - node.radius}px`,
+      color: node.color,
+      opacity: 0.85,
+      popularity: node.popularity
+    }
+  })
+})
 
 onMounted(() => {
   fetchNews()
 })
+
+onUnmounted(() => {
+  // シミュレーションを停止
+  if (simulation) {
+    simulation.stop()
+  }
+})
 </script>
 
 <template>
-  <div class="news-container flex">
-    <div v-if="news" class="flex">
-      <div class="news-column large">
-        <NewsItem
-          v-for="(result, index) in news.results.slice(0, 1)"
-          :key="result.title"
-          :result="result"
-          size="large"
-        />
-      </div>
-      <div class="news-column medium">
-        <NewsItem
-          v-for="(result, index) in news.results.slice(1, 3)"
-          :key="result.title"
-          :result="result"
-          size="medium"
-        />
-      </div>
-      <div class="news-column small">
-        <NewsItem
-          v-for="(result, index) in news.results.slice(3, 6)"
-          :key="result.title"
-          :result="result"
-          size="small"
-        />
-      </div>
+  <div class="news-cloud-container">
+    <!-- デバッグ情報 -->
+    <div style="position: fixed; top: 100px; right: 10px; background: #f0f0f0; padding: 10px; font-size: 12px; z-index: 1000;">
+      <div>Loading: {{ loading }}</div>
+      <div>Error: {{ error }}</div>
+      <div>Articles: {{ articles.length }}</div>
+      <div>API Key: {{ newsApiKey ? 'Set' : 'Not Set' }}</div>
+    </div>
+
+    <!-- ローディング表示 -->
+    <div v-if="loading" class="loading">
+      <p>ニュースを読み込み中...</p>
+    </div>
+
+    <!-- エラー表示 -->
+    <div v-else-if="error" class="error">
+      <p>{{ error }}</p>
+      <button @click="fetchNews" class="retry-button">再読み込み</button>
+    </div>
+
+    <!-- バブル風ニュース表示（物理シミュレーション） -->
+    <div v-else class="news-cloud">
+      <a
+        v-for="(item, index) in styledArticles"
+        :key="index"
+        :href="item.article.url"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="news-bubble"
+        :style="{
+          width: item.bubbleSize,
+          height: item.bubbleSize,
+          fontSize: item.fontSize,
+          left: item.left,
+          top: item.top,
+          backgroundColor: item.color,
+          opacity: item.opacity,
+          transform: 'translate(0, 0)' // GPUアクセラレーション
+        }"
+        :title="item.article.description || item.article.title"
+      >
+        <div class="bubble-content">
+          <div class="bubble-title">{{ item.article.title }}</div>
+          <div class="bubble-source">{{ item.article.source.name }}</div>
+        </div>
+      </a>
     </div>
   </div>
 </template>
 
 <style scoped>
-.news-column {
+.news-cloud-container {
+  width: 100%;
+  min-height: calc(100vh - 200px);
+  position: relative;
+  padding: 2rem;
+}
+
+.loading, .error {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  font-size: 1.2rem;
+  color: #666;
 }
 
-.news-column.large {
-  flex: 2;
+.error {
+  color: #d32f2f;
 }
 
-.news-column.medium {
-  flex: 1;
+.retry-button {
+  margin-top: 1rem;
+  padding: 0.5rem 1.5rem;
+  background-color: #4ECDC4;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.3s;
 }
 
-.news-column.small {
-  flex: 1;
+.retry-button:hover {
+  background-color: #45B7D1;
 }
 
+.news-cloud {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 250px);
+  min-height: 600px;
+  overflow: hidden;
+}
+
+.news-bubble {
+  position: absolute;
+  text-decoration: none;
+  transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease, border-width 0.3s ease;
+  cursor: pointer;
+  border-radius: 50%; /* 完全な円形 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  will-change: transform;
+}
+
+.bubble-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.5rem;
+  width: 100%;
+  height: 100%;
+  color: white;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.bubble-title {
+  font-weight: 700;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  margin-bottom: 0.5rem;
+}
+
+.bubble-source {
+  font-size: 0.7em;
+  opacity: 0.9;
+  font-weight: 500;
+  margin-top: 0.3rem;
+}
+
+.news-bubble:hover {
+  transform: scale(1.2);
+  opacity: 1 !important;
+  z-index: 100;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.35);
+  border-width: 4px;
+}
+
+.news-bubble:hover .bubble-title {
+  -webkit-line-clamp: 6;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .news-cloud {
+    height: calc(100vh - 200px);
+    min-height: 500px;
+  }
+
+  .bubble-content {
+    padding: 1rem;
+  }
+
+  .bubble-title {
+    -webkit-line-clamp: 3;
+  }
+}
+
+/* 初期アニメーション */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 0.85;
+    transform: scale(1);
+  }
+}
+
+.news-cloud > a {
+  animation: fadeIn 0.8s ease-out forwards;
+}
+
+.news-cloud > a:nth-child(n) {
+  animation-delay: calc(var(--index, 0) * 0.03s);
+}
 </style>


### PR DESCRIPTION
## 概要
ニュース表示をワードクラウド風からバブル（泡）UIに刷新。
News API top-headlinesの掲載順（人気度）に応じて泡のサイズが変わり、
d3-forceの物理シミュレーションにより泡同士が重ならず自然に配置される。

## 変更内容
- News APIのエンドポイントを `/v2/everything?sortBy=popularity` から
  `/v2/top-headlines` に変更（無料プランでpopularityが返らない問題を修正）
- ニュース記事を丸い泡として表示するUIに変更
- 人気度が高い記事ほど泡が大きく表示される（80px〜280px）
- `d3-force` を導入し、泡同士が反発し合う物理シミュレーションを実装
- ホバー時に泡が拡大し、記事タイトルとソース名を表示

## 使用ライブラリ
- `d3-force` ^3.0.0 — 物理シミュレーション
- `d3-selection` ^3.0.0 — 補助

## スクリーンショット
<!-- 画面キャプチャがあれば添付 -->
